### PR TITLE
Fix loading of CSS in GH Pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
     "serve-dist": "cd dist; http-server"
   },
   "license": "MIT",
+  "targets": {
+    "default": {
+      "publicUrl": "./"
+    }
+  },
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@parcel/compressor-brotli": "^2.13.3",


### PR DESCRIPTION
This is necessary because the site is deployed at the subpath `/utm-link-generator`.