### PR TITLE
Determine specific errors in link generation

### DIFF
--- a/src/ts/linkGenerator.ts
+++ b/src/ts/linkGenerator.ts
@@ -1,3 +1,4 @@
+import { OPTIONS } from "./config/options";
 import { FormState } from "./state/FormState";
 import Observable from "./state/Observable";
 
@@ -26,28 +27,45 @@ export function generateLink(state: FormState): Result {
   switch (state.type) {
     case "ad":
       medium = state.adOptions.medium;
-      campaignName = state.adOptions.campaignName;
       if (!medium) {
-        // TODO: dry the question name in config
-        errors.push(`Missing "Medium"`);
+        errors.push(`Missing "${OPTIONS.ad.medium.label}"`);
+      }
+      campaignName = state.adOptions.campaignName;
+      if (!campaignName) {
+        errors.push(`Missing "${OPTIONS.ad.campaignName.label}"`);
       }
       break;
     case "email":
       medium = "email";
       source = state.emailOptions.source;
+      if (!source) {
+        errors.push(`Missing "${OPTIONS.email.source.label}"`);
+      }
       break;
     case "field":
       medium = "field";
       source = state.fieldOptions.source;
+      if (!source) {
+        errors.push(`Missing "${OPTIONS.field.source.label}"`);
+      }
       campaignName = state.fieldOptions.campaignName;
+      if (!campaignName) {
+        errors.push(`Missing "${OPTIONS.field.campaignName.label}"`);
+      }
       break;
     case "social":
       medium = "organic_social";
       source = state.socialOptions.source;
+      if (!source) {
+        errors.push(`Missing "${OPTIONS.social.source.label}"`);
+      }
       campaignName = state.socialOptions.campaignName;
+      if (!campaignName) {
+        errors.push(`Missing "${OPTIONS.social.campaignName.label}"`);
+      }
       break;
     default:
-      errors.push("Missing communication type");
+      errors.push(`Missing "${OPTIONS.communicationType.label}"`);
   }
 
   const queryParam = generateUtmString({

--- a/tests/linkGenerator.test.ts
+++ b/tests/linkGenerator.test.ts
@@ -28,42 +28,89 @@ test.describe("generateLink()", () => {
     },
   };
 
-  test("missing URL and type", () => {
-    expect(generateLink({ ...DEFAULT, url: undefined })).toBeNull();
-    expect(generateLink({ ...DEFAULT, type: undefined })).toBeNull();
+  test("missing URL", () => {
+    expect(generateLink({ ...DEFAULT, url: undefined })).toEqual({
+      success: false,
+      errors: ["Missing URL"],
+    });
+  });
+
+  test("missing communication type", () => {
+    expect(generateLink({ ...DEFAULT, type: undefined })).toEqual({
+      success: false,
+      errors: ['Missing "Communication type"'],
+    });
   });
 
   test("ad options", () => {
     const ad: FormState = { ...DEFAULT, type: "ad" };
-    expect(generateLink(ad)).toEqual(
-      `${DEFAULT_URL}?utm_medium=paid_social&utm_campaign=lead_gen`,
-    );
+    expect(generateLink(ad)).toEqual({
+      success: true,
+      url: `${DEFAULT_URL}?utm_medium=paid_social&utm_campaign=lead_gen`,
+    });
+
     expect(
       generateLink({
         ...ad,
-        adOptions: { ...DEFAULT.adOptions, medium: undefined },
+        adOptions: { medium: undefined, campaignName: undefined },
       }),
-    ).toBeNull();
+    ).toEqual({
+      success: false,
+      errors: ['Missing "Medium"', 'Missing "Primary purpose"'],
+    });
   });
 
   test("email options", () => {
     const email: FormState = { ...DEFAULT, type: "email" };
-    expect(generateLink(email)).toEqual(
-      `${DEFAULT_URL}?utm_medium=email&utm_source=mailchimp`,
-    );
+    expect(generateLink(email)).toEqual({
+      success: true,
+      url: `${DEFAULT_URL}?utm_medium=email&utm_source=mailchimp`,
+    });
+
+    expect(
+      generateLink({
+        ...email,
+        emailOptions: { source: undefined },
+      }),
+    ).toEqual({
+      success: false,
+      errors: ['Missing "Source"'],
+    });
   });
 
   test("field options", () => {
     const field: FormState = { ...DEFAULT, type: "field" };
-    expect(generateLink(field)).toEqual(
-      `${DEFAULT_URL}?utm_medium=field&utm_source=poster&utm_campaign=lead_gen`,
-    );
+    expect(generateLink(field)).toEqual({
+      success: true,
+      url: `${DEFAULT_URL}?utm_medium=field&utm_source=poster&utm_campaign=lead_gen`,
+    });
+
+    expect(
+      generateLink({
+        ...field,
+        fieldOptions: { source: undefined, campaignName: undefined },
+      }),
+    ).toEqual({
+      success: false,
+      errors: ['Missing "Source"', 'Missing "Primary purpose"'],
+    });
   });
 
   test("social media options", () => {
     const social: FormState = { ...DEFAULT, type: "social" };
-    expect(generateLink(social)).toEqual(
-      `${DEFAULT_URL}?utm_medium=organic_social&utm_source=instagram&utm_campaign=proanimaldc`,
-    );
+    expect(generateLink(social)).toEqual({
+      success: true,
+      url: `${DEFAULT_URL}?utm_medium=organic_social&utm_source=instagram&utm_campaign=proanimaldc`,
+    });
+
+    expect(
+      generateLink({
+        ...social,
+        socialOptions: { source: undefined, campaignName: undefined },
+      }),
+    ).toEqual({
+      success: false,
+      errors: ['Missing "Source"', 'Missing "Account name"'],
+    });
   });
 });


### PR DESCRIPTION
This new paradigm is much better. We now result something like Rust's `Result`, whereas before we turned the equivalent of `Option`.

This allows us to:

* Give more useful error messages
* Have >1 error
* Have errors specific to each communication type, e.g. a question may be required in one but not the other

We don't yet surface these errors to the end user, but that will be a follow up.