### PR TITLE
Add source field for ads

### DIFF
--- a/src/ts/config/options.ts
+++ b/src/ts/config/options.ts
@@ -17,12 +17,10 @@ export const OPTIONS = {
         {
           value: "paid_social",
           label: "Social media ads",
-          description: "Meta, Reddit, etc.",
         },
         {
           value: "paid_search",
           label: "Search ads",
-          description: "Google, Bing, etc.",
         },
         {
           value: "paid_ooh",
@@ -32,11 +30,34 @@ export const OPTIONS = {
         {
           value: "paid_sms",
           label: "Text blasts",
-          description: "E.g. Scale to Win",
         },
         { value: "paid_mail", label: "Mass-mailed voter mailers" },
         { value: "paid_tv", label: "TV commercials" },
       ],
+    },
+    source: {
+      social: {
+        id: "ad-source-social",
+        label: "Source",
+        options: [
+          { value: "meta", label: "Meta" },
+          { value: "reddit", label: "Reddit" },
+          { value: "youtube", label: "YouTube" },
+        ],
+      },
+      search: {
+        id: "ad-source-search",
+        label: "Source",
+        options: [
+          { value: "google", label: "Google" },
+          { value: "bing", label: "Bing" },
+        ],
+      },
+      outOfHome: {
+        id: "ad-source-out-of-home",
+        label: "Source",
+        options: [{ value: "billboard", label: "Billboard" }],
+      },
     },
     campaignName: {
       id: "ad-campaign-name",

--- a/src/ts/form/initForm.ts
+++ b/src/ts/form/initForm.ts
@@ -99,26 +99,9 @@ function initAdOptions(
     container,
     formState,
     OPTIONS.ad.medium,
-    (value, priorState) => {
-      let source: string | undefined;
-      switch (value) {
-        case "paid_mail":
-          source = "mailer";
-          break;
-        case "paid_sms":
-          source = "scaletowin";
-          break;
-        case "paid_tv":
-          source = "tv";
-          break;
-        default:
-          source = undefined;
-          break;
-      }
-      return {
-        adOptions: { ...priorState.adOptions, medium: value, source },
-      };
-    },
+    (value, priorState) => ({
+      adOptions: { ...priorState.adOptions, medium: value },
+    }),
   );
 
   initRadioGroup(
@@ -126,7 +109,10 @@ function initAdOptions(
     formState,
     OPTIONS.ad.source.search,
     (value, priorState) => ({
-      adOptions: { ...priorState.adOptions, source: value },
+      adOptions: {
+        ...priorState.adOptions,
+        source: { ...priorState.adOptions.source, search: value },
+      },
     }),
     (state) => state.adOptions.medium !== "paid_search",
   );
@@ -136,7 +122,10 @@ function initAdOptions(
     formState,
     OPTIONS.ad.source.social,
     (value, priorState) => ({
-      adOptions: { ...priorState.adOptions, source: value },
+      adOptions: {
+        ...priorState.adOptions,
+        source: { ...priorState.adOptions.source, social: value },
+      },
     }),
     (state) => state.adOptions.medium !== "paid_social",
   );
@@ -146,7 +135,10 @@ function initAdOptions(
     formState,
     OPTIONS.ad.source.outOfHome,
     (value, priorState) => ({
-      adOptions: { ...priorState.adOptions, source: value },
+      adOptions: {
+        ...priorState.adOptions,
+        source: { ...priorState.adOptions.source, outOfHome: value },
+      },
     }),
     (state) => state.adOptions.medium !== "paid_ooh",
   );

--- a/src/ts/form/initForm.ts
+++ b/src/ts/form/initForm.ts
@@ -25,10 +25,18 @@ function initRadioGroup(
   formState: Observable<FormState>,
   request: RadioGroup,
   updateFn: UpdateFormStateFunction,
+  hideFn?: (state: FormState) => boolean,
 ): void {
   const group = generateRadioGroup(request);
   group.addEventListener("change", updateFormState(formState)(updateFn));
   parent.appendChild(group);
+
+  if (hideFn) {
+    formState.subscribe((state) => {
+      const isHidden = hideFn(state);
+      group.hidden = isHidden;
+    });
+  }
 }
 
 function initUrl(
@@ -91,15 +99,61 @@ function initAdOptions(
     container,
     formState,
     OPTIONS.ad.medium,
-    (value, priorState) => ({
-      adOptions: { ...priorState.adOptions, medium: value },
-    }),
+    (value, priorState) => {
+      let source: string | undefined;
+      switch (value) {
+        case "paid_mail":
+          source = "mailer";
+          break;
+        case "paid_sms":
+          source = "scaletowin";
+          break;
+        case "paid_tv":
+          source = "tv";
+          break;
+        default:
+          source = undefined;
+          break;
+      }
+      return {
+        adOptions: { ...priorState.adOptions, medium: value, source },
+      };
+    },
   );
 
   initRadioGroup(
     container,
     formState,
+    OPTIONS.ad.source.search,
+    (value, priorState) => ({
+      adOptions: { ...priorState.adOptions, source: value },
+    }),
+    (state) => state.adOptions.medium !== "paid_search",
+  );
 
+  initRadioGroup(
+    container,
+    formState,
+    OPTIONS.ad.source.social,
+    (value, priorState) => ({
+      adOptions: { ...priorState.adOptions, source: value },
+    }),
+    (state) => state.adOptions.medium !== "paid_social",
+  );
+
+  initRadioGroup(
+    container,
+    formState,
+    OPTIONS.ad.source.outOfHome,
+    (value, priorState) => ({
+      adOptions: { ...priorState.adOptions, source: value },
+    }),
+    (state) => state.adOptions.medium !== "paid_ooh",
+  );
+
+  initRadioGroup(
+    container,
+    formState,
     OPTIONS.ad.campaignName,
     (value, priorState) => ({
       adOptions: { ...priorState.adOptions, campaignName: value },

--- a/src/ts/linkGenerator.ts
+++ b/src/ts/linkGenerator.ts
@@ -30,6 +30,10 @@ export function generateLink(state: FormState): Result {
       if (!medium) {
         errors.push(`Missing "${OPTIONS.ad.medium.label}"`);
       }
+      source = state.adOptions.source;
+      if (medium && !source) {
+        errors.push(`Missing "${OPTIONS.ad.source.search.label}"`);
+      }
       campaignName = state.adOptions.campaignName;
       if (!campaignName) {
         errors.push(`Missing "${OPTIONS.ad.campaignName.label}"`);

--- a/src/ts/linkGenerator.ts
+++ b/src/ts/linkGenerator.ts
@@ -1,5 +1,5 @@
 import { OPTIONS } from "./config/options";
-import { FormState } from "./state/FormState";
+import { AdOptions, FormState } from "./state/FormState";
 import Observable from "./state/Observable";
 
 function generateUtmString(
@@ -14,6 +14,27 @@ function generateUtmString(
 type Result =
   | { success: true; url: string }
   | { success: false; errors: string[] };
+
+function determineAdSource(adOptions: AdOptions): string | undefined {
+  switch (adOptions.medium) {
+    case undefined:
+      return undefined;
+    case "paid_mail":
+      return "mailer";
+    case "paid_sms":
+      return "scaletowin";
+    case "paid_tv":
+      return "tv";
+    case "paid_social":
+      return adOptions.source.social;
+    case "paid_search":
+      return adOptions.source.search;
+    case "paid_ooh":
+      return adOptions.source.outOfHome;
+    default:
+      throw new Error(`Unexpected medium "${adOptions.medium}"`);
+  }
+}
 
 export function generateLink(state: FormState): Result {
   const errors: string[] = [];
@@ -30,7 +51,7 @@ export function generateLink(state: FormState): Result {
       if (!medium) {
         errors.push(`Missing "${OPTIONS.ad.medium.label}"`);
       }
-      source = state.adOptions.source;
+      source = determineAdSource(state.adOptions);
       if (medium && !source) {
         errors.push(`Missing "${OPTIONS.ad.source.search.label}"`);
       }

--- a/src/ts/state/FormState.ts
+++ b/src/ts/state/FormState.ts
@@ -4,6 +4,7 @@ export type CommunicationType = "ad" | "email" | "field" | "social";
 
 export interface AdOptions {
   medium: string | undefined;
+  source: string | undefined;
   campaignName: string | undefined;
 }
 
@@ -36,6 +37,7 @@ export function initFormState(): Observable<FormState> {
     type: undefined,
     adOptions: {
       medium: undefined,
+      source: undefined,
       campaignName: undefined,
     },
     emailOptions: { source: undefined },

--- a/src/ts/state/FormState.ts
+++ b/src/ts/state/FormState.ts
@@ -4,7 +4,11 @@ export type CommunicationType = "ad" | "email" | "field" | "social";
 
 export interface AdOptions {
   medium: string | undefined;
-  source: string | undefined;
+  source: {
+    social: string | undefined;
+    search: string | undefined;
+    outOfHome: string | undefined;
+  };
   campaignName: string | undefined;
 }
 
@@ -37,7 +41,11 @@ export function initFormState(): Observable<FormState> {
     type: undefined,
     adOptions: {
       medium: undefined,
-      source: undefined,
+      source: {
+        social: undefined,
+        search: undefined,
+        outOfHome: undefined,
+      },
       campaignName: undefined,
     },
     emailOptions: { source: undefined },

--- a/tests/linkGenerator.test.ts
+++ b/tests/linkGenerator.test.ts
@@ -13,7 +13,11 @@ test.describe("generateLink()", () => {
     type: "email",
     adOptions: {
       medium: "paid_social",
-      source: "meta",
+      source: {
+        social: "meta",
+        search: undefined,
+        outOfHome: undefined,
+      },
       campaignName: "lead_gen",
     },
     emailOptions: {
@@ -55,7 +59,11 @@ test.describe("generateLink()", () => {
         ...ad,
         adOptions: {
           medium: undefined,
-          source: undefined,
+          source: {
+            search: undefined,
+            social: undefined,
+            outOfHome: undefined,
+          },
           campaignName: undefined,
         },
       }),
@@ -69,11 +77,29 @@ test.describe("generateLink()", () => {
     expect(
       generateLink({
         ...ad,
-        adOptions: { ...ad.adOptions, source: undefined },
+        adOptions: {
+          ...ad.adOptions,
+          source: {
+            social: undefined,
+            search: undefined,
+            outOfHome: undefined,
+          },
+        },
       }),
     ).toEqual({
       success: false,
       errors: ['Missing "Source"'],
+    });
+
+    // Certain mediums imply the `source`.
+    expect(
+      generateLink({
+        ...ad,
+        adOptions: { ...ad.adOptions, medium: "paid_tv" },
+      }),
+    ).toEqual({
+      success: true,
+      url: `${DEFAULT_URL}?utm_medium=paid_tv&utm_source=tv&utm_campaign=lead_gen`,
     });
   });
 

--- a/tests/linkGenerator.test.ts
+++ b/tests/linkGenerator.test.ts
@@ -13,6 +13,7 @@ test.describe("generateLink()", () => {
     type: "email",
     adOptions: {
       medium: "paid_social",
+      source: "meta",
       campaignName: "lead_gen",
     },
     emailOptions: {
@@ -46,17 +47,33 @@ test.describe("generateLink()", () => {
     const ad: FormState = { ...DEFAULT, type: "ad" };
     expect(generateLink(ad)).toEqual({
       success: true,
-      url: `${DEFAULT_URL}?utm_medium=paid_social&utm_campaign=lead_gen`,
+      url: `${DEFAULT_URL}?utm_medium=paid_social&utm_source=meta&utm_campaign=lead_gen`,
     });
 
     expect(
       generateLink({
         ...ad,
-        adOptions: { medium: undefined, campaignName: undefined },
+        adOptions: {
+          medium: undefined,
+          source: undefined,
+          campaignName: undefined,
+        },
       }),
     ).toEqual({
       success: false,
+      // Note that we don't complain about `source` because it depends on the medium.
       errors: ['Missing "Medium"', 'Missing "Primary purpose"'],
+    });
+
+    /// Once the `medium` is set, we expect `source` to also be set.
+    expect(
+      generateLink({
+        ...ad,
+        adOptions: { ...ad.adOptions, source: undefined },
+      }),
+    ).toEqual({
+      success: false,
+      errors: ['Missing "Source"'],
     });
   });
 


### PR DESCRIPTION
This one is tricky because the `source` field depends on the `medium`. It can sometimes be auto-computed, whereas otherwise its options are not shared with the other mediums.