### PR TITLE
Validate URL

### DIFF
--- a/src/ts/form/initForm.ts
+++ b/src/ts/form/initForm.ts
@@ -60,7 +60,7 @@ function initUrl(
 
   input.addEventListener(
     "change",
-    updateFormState(formState)((value) => ({ url: value })),
+    updateFormState(formState)((value) => ({ url: value.trim() })),
   );
 }
 

--- a/src/ts/linkGenerator.ts
+++ b/src/ts/linkGenerator.ts
@@ -15,6 +15,23 @@ type Result =
   | { success: true; url: string }
   | { success: false; errors: string[] };
 
+function validateUrl(url: string | undefined): Result {
+  if (!url) {
+    return { success: false, errors: ["Missing URL"] };
+  } else {
+    if (!url.startsWith("https://")) {
+      return { success: false, errors: ["URL must start with https://"] };
+    }
+    try {
+      new URL(url);
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (_) {
+      return { success: false, errors: ["Invalid URL"] };
+    }
+  }
+  return { success: true, url: url };
+}
+
 function determineAdSource(adOptions: AdOptions): string | undefined {
   switch (adOptions.medium) {
     case undefined:
@@ -38,8 +55,10 @@ function determineAdSource(adOptions: AdOptions): string | undefined {
 
 export function generateLink(state: FormState): Result {
   const errors: string[] = [];
-  if (!state.url) {
-    errors.push("Missing URL");
+
+  const urlResult = validateUrl(state.url);
+  if (!urlResult.success) {
+    errors.push(...urlResult.errors);
   }
 
   let medium: string | undefined;

--- a/tests/linkGenerator.test.ts
+++ b/tests/linkGenerator.test.ts
@@ -33,10 +33,20 @@ test.describe("generateLink()", () => {
     },
   };
 
-  test("missing URL", () => {
+  test("URL", () => {
     expect(generateLink({ ...DEFAULT, url: undefined })).toEqual({
       success: false,
       errors: ["Missing URL"],
+    });
+    expect(generateLink({ ...DEFAULT, url: "proanimal.org" })).toEqual({
+      success: false,
+      errors: ["URL must start with https://"],
+    });
+    expect(
+      generateLink({ ...DEFAULT, url: "https://proanimal.org a13b" }),
+    ).toEqual({
+      success: false,
+      errors: ["Invalid URL"],
     });
   });
 


### PR DESCRIPTION
I decided error messages will be consoldiated at the bottom, rather than trying to show the error near the source field itself. Maybe less optimal UX, but much simpler.