### PR TITLE
Review feedback: embrace UTM values

### DIFF
--- a/src/ts/config/options.ts
+++ b/src/ts/config/options.ts
@@ -1,133 +1,131 @@
+export const MEDIUM_LABEL = "utm_medium";
+export const SOURCE_LABEL = "utm_source";
+export const CAMPAIGN_NAME_LABEL = "utm_campaign";
+
+const CAMPAIGN_PURPOSE_OPTIONS = [
+  { value: "fundraising" },
+  { value: "lead_gen" },
+  { value: "recruitment" },
+  { value: "voter_persuasion" },
+] as const;
+
+const ACCOUNT_NAME_OPTIONS = [
+  { value: "proanimalcolorado" },
+  { value: "proanimalfuture" },
+  { value: "proanimaloregon" },
+  { value: "nattiefulton" },
+];
+
 export const OPTIONS = {
-  communicationType: {
-    id: "communication-type",
-    label: "Communication type",
+  medium: {
+    id: "medium",
+    label: MEDIUM_LABEL,
     options: [
-      { value: "ad", label: "Advertisement" },
-      { value: "email", label: "Email" },
-      { value: "field", label: "Field" },
-      { value: "social", label: "Organic social media" },
+      { value: "email" },
+      { value: "field" },
+      { value: "organic_social" },
+      { value: "paid_mail" },
+      { value: "paid_search" },
+      { value: "paid_social" },
+      { value: "paid_sms" },
     ],
-  },
-  ad: {
-    medium: {
-      id: "ad-medium",
-      label: "Medium",
-      options: [
-        {
-          value: "paid_social",
-          label: "Social media ads",
-        },
-        {
-          value: "paid_search",
-          label: "Search ads",
-        },
-        {
-          value: "paid_ooh",
-          label: "Out-of-home ads",
-          description: "Billboards, transit ads, bus shelters",
-        },
-        {
-          value: "paid_sms",
-          label: "Text blasts",
-        },
-        { value: "paid_mail", label: "Mass-mailed voter mailers" },
-        { value: "paid_tv", label: "TV commercials" },
-      ],
-    },
-    source: {
-      social: {
-        id: "ad-source-social",
-        label: "Source",
-        options: [
-          { value: "meta", label: "Meta" },
-          { value: "reddit", label: "Reddit" },
-          { value: "youtube", label: "YouTube" },
-        ],
-      },
-      search: {
-        id: "ad-source-search",
-        label: "Source",
-        options: [
-          { value: "google", label: "Google" },
-          { value: "bing", label: "Bing" },
-        ],
-      },
-      outOfHome: {
-        id: "ad-source-out-of-home",
-        label: "Source",
-        options: [{ value: "billboard", label: "Billboard" }],
-      },
-    },
-    campaignName: {
-      id: "ad-campaign-name",
-      label: "Primary purpose",
-      options: [
-        { value: "lead_gen", label: "Lead generation" },
-        { value: "fundraising", label: "Fundraising" },
-        { value: "recruitment", label: "Recruitment" },
-        { value: "voter_persuasion", label: "Voter Persuasion" },
-      ],
-    },
   },
   email: {
     source: {
       id: "email-source",
-      label: "Source",
+      label: SOURCE_LABEL,
       options: [
-        { value: "substack", label: "Substack" },
-        { value: "mailchimp", label: "Mailchimp" },
-        { value: "sendgrid", label: "SendGrid" },
+        { value: "substack" },
+        { value: "mailchimp" },
+        { value: "sendgrid" },
       ],
+    },
+    campaignName: {
+      id: "email-campaign-name",
+      label: CAMPAIGN_NAME_LABEL,
+      options: ACCOUNT_NAME_OPTIONS,
     },
   },
   field: {
     source: {
       id: "field-source",
-      label: "Source",
+      label: SOURCE_LABEL,
       options: [
-        { value: "poster", label: "Poster" },
-        { value: "sticker", label: "Sticker" },
-        { value: "aframe", label: "Aframe" },
-        { value: "postcard", label: "Postcard" },
-        { value: "handout", label: "Handout" },
-        { value: "tablecloth", label: "Table cloth" },
+        { value: "aframe" },
+        { value: "handout" },
+        { value: "postcard" },
+        { value: "poster" },
+        { value: "sticker" },
+        { value: "tablecloth" },
       ],
     },
     campaignName: {
       id: "field-campaign-name",
-      label: "Primary purpose",
-      options: [
-        { value: "lead_gen", label: "Lead generation" },
-        { value: "fundraising", label: "Fundraising" },
-        { value: "recruitment", label: "Recruitment" },
-        { value: "voter_persuasion", label: "Voter Persuasion" },
-      ],
+      label: CAMPAIGN_NAME_LABEL,
+      options: CAMPAIGN_PURPOSE_OPTIONS,
     },
   },
-  social: {
+  organicSocial: {
     source: {
-      id: "social-source",
-      label: "Source",
+      id: "organic-social-source",
+      label: SOURCE_LABEL,
       options: [
-        { value: "instagram", label: "Instagram" },
-        { value: "facebook", label: "Facebook" },
-        { value: "youtube", label: "YouTube" },
-        { value: "x", label: "X" },
-        { value: "nextdoor", label: "Nextdoor" },
-        { value: "bluesky", label: "Bluesky" },
+        { value: "facebook" },
+        { value: "instagram" },
+        { value: "nextdoor" },
+        { value: "slack" },
+        { value: "tiktok" },
+        { value: "x" },
+        { value: "youtube" },
       ],
     },
     campaignName: {
-      id: "social-campaign-name",
-      label: "Account name",
-      options: [
-        { value: "proanimaloregon", label: "Pro-Animal Oregon" },
-        { value: "proanimaldc", label: "Pro-Animal DC" },
-        { value: "proanimalcolorado", label: "Pro-Animal Colorado" },
-        { value: "proanimalfuture", label: "Pro-Animal Future" },
-        { value: "nattiefulton", label: "Natalie Fulton" },
-      ],
+      id: "organic-social-campaign-name",
+      label: CAMPAIGN_NAME_LABEL,
+      options: ACCOUNT_NAME_OPTIONS,
     },
   },
-};
+  paidMail: {
+    campaignName: {
+      id: "paid-mail-campaign-name",
+      label: CAMPAIGN_NAME_LABEL,
+      options: CAMPAIGN_PURPOSE_OPTIONS,
+    },
+  },
+  paidSearch: {
+    source: {
+      id: "paid-search-source",
+      label: SOURCE_LABEL,
+      options: [{ value: "google" }],
+    },
+    campaignName: {
+      id: "paid-search-campaign-name",
+      label: CAMPAIGN_NAME_LABEL,
+      options: CAMPAIGN_PURPOSE_OPTIONS,
+    },
+  },
+  paidSocial: {
+    source: {
+      id: "paid-social-source",
+      label: SOURCE_LABEL,
+      options: [{ value: "meta" }, { value: "youtube" }],
+    },
+    campaignName: {
+      id: "paid-social-campaign-name",
+      label: CAMPAIGN_NAME_LABEL,
+      options: CAMPAIGN_PURPOSE_OPTIONS,
+    },
+  },
+  paidSms: {
+    source: {
+      id: "paid-sms-source",
+      label: SOURCE_LABEL,
+      options: [{ value: "scaletowin" }],
+    },
+    campaignName: {
+      id: "paid-sms-campaign-name",
+      label: CAMPAIGN_NAME_LABEL,
+      options: CAMPAIGN_PURPOSE_OPTIONS,
+    },
+  },
+} as const;

--- a/src/ts/form/initForm.ts
+++ b/src/ts/form/initForm.ts
@@ -1,5 +1,5 @@
 import { OPTIONS } from "../config/options";
-import { CommunicationType, FormState } from "../state/FormState";
+import { Medium, FormState } from "../state/FormState";
 import Observable from "../state/Observable";
 import { generateRadioGroup, RadioGroup } from "./radio";
 
@@ -48,7 +48,7 @@ function initUrl(
   form.appendChild(container);
 
   const label = document.createElement("label");
-  label.textContent = "Your URL";
+  label.textContent = "PAF URL";
   label.htmlFor = "url-input";
   container.appendChild(label);
 
@@ -64,108 +64,52 @@ function initUrl(
   );
 }
 
-function initCommunicationTypeQuestion(
+function initMediumQuestion(
   form: HTMLFormElement,
   formState: Observable<FormState>,
 ): void {
-  initRadioGroup(form, formState, OPTIONS.communicationType, (value) => ({
-    type: value as CommunicationType,
+  initRadioGroup(form, formState, OPTIONS.medium, (value) => ({
+    medium: value as Medium,
   }));
 }
 
-function initCommunicationTypeDiv(
+function initMediumQuestionsDiv(
   form: HTMLFormElement,
   formState: Observable<FormState>,
-  communicationType: CommunicationType,
+  medium: Medium,
 ): HTMLDivElement {
   const container = document.createElement("div");
-  container.id = `${communicationType}-options`;
+  container.id = `${medium}-options`;
   container.hidden = true;
   form.appendChild(container);
 
-  formState.subscribe(({ type }) => {
-    container.hidden = type !== communicationType;
+  formState.subscribe(({ medium: type }) => {
+    container.hidden = type !== medium;
   });
   return container;
-}
-
-function initAdOptions(
-  form: HTMLFormElement,
-  formState: Observable<FormState>,
-): void {
-  const container = initCommunicationTypeDiv(form, formState, "ad");
-
-  initRadioGroup(
-    container,
-    formState,
-    OPTIONS.ad.medium,
-    (value, priorState) => ({
-      adOptions: { ...priorState.adOptions, medium: value },
-    }),
-  );
-
-  initRadioGroup(
-    container,
-    formState,
-    OPTIONS.ad.source.search,
-    (value, priorState) => ({
-      adOptions: {
-        ...priorState.adOptions,
-        source: { ...priorState.adOptions.source, search: value },
-      },
-    }),
-    (state) => state.adOptions.medium !== "paid_search",
-  );
-
-  initRadioGroup(
-    container,
-    formState,
-    OPTIONS.ad.source.social,
-    (value, priorState) => ({
-      adOptions: {
-        ...priorState.adOptions,
-        source: { ...priorState.adOptions.source, social: value },
-      },
-    }),
-    (state) => state.adOptions.medium !== "paid_social",
-  );
-
-  initRadioGroup(
-    container,
-    formState,
-    OPTIONS.ad.source.outOfHome,
-    (value, priorState) => ({
-      adOptions: {
-        ...priorState.adOptions,
-        source: { ...priorState.adOptions.source, outOfHome: value },
-      },
-    }),
-    (state) => state.adOptions.medium !== "paid_ooh",
-  );
-
-  initRadioGroup(
-    container,
-    formState,
-    OPTIONS.ad.campaignName,
-    (value, priorState) => ({
-      adOptions: { ...priorState.adOptions, campaignName: value },
-    }),
-  );
 }
 
 function initEmailOptions(
   form: HTMLFormElement,
   formState: Observable<FormState>,
 ): void {
-  const container = initCommunicationTypeDiv(form, formState, "email");
+  const container = initMediumQuestionsDiv(form, formState, "email");
 
   initRadioGroup(
     container,
     formState,
-
     OPTIONS.email.source,
     (value, priorState) => ({
-      emailOptions: { ...priorState.emailOptions, source: value },
+      email: { ...priorState.email, source: value },
+    }),
+  );
+
+  initRadioGroup(
+    container,
+    formState,
+    OPTIONS.email.campaignName,
+    (value, priorState) => ({
+      email: { ...priorState.email, campaignName: value },
     }),
   );
 }
@@ -174,52 +118,145 @@ function initFieldOptions(
   form: HTMLFormElement,
   formState: Observable<FormState>,
 ): void {
-  const container = initCommunicationTypeDiv(form, formState, "field");
+  const container = initMediumQuestionsDiv(form, formState, "field");
 
   initRadioGroup(
     container,
     formState,
-
     OPTIONS.field.source,
     (value, priorState) => ({
-      fieldOptions: { ...priorState.fieldOptions, source: value },
+      field: { ...priorState.field, source: value },
     }),
   );
 
   initRadioGroup(
     container,
     formState,
-
     OPTIONS.field.campaignName,
     (value, priorState) => ({
-      fieldOptions: { ...priorState.fieldOptions, campaignName: value },
+      field: { ...priorState.field, campaignName: value },
     }),
   );
 }
 
-function initSocialOptions(
+function initOrganicSocialOptions(
   form: HTMLFormElement,
   formState: Observable<FormState>,
 ): void {
-  const container = initCommunicationTypeDiv(form, formState, "social");
+  const container = initMediumQuestionsDiv(form, formState, "organic_social");
 
   initRadioGroup(
     container,
     formState,
-
-    OPTIONS.social.source,
+    OPTIONS.organicSocial.source,
     (value, priorState) => ({
-      socialOptions: { ...priorState.socialOptions, source: value },
+      organicSocial: {
+        ...priorState.organicSocial,
+        source: value,
+      },
     }),
   );
 
   initRadioGroup(
     container,
     formState,
-
-    OPTIONS.social.campaignName,
+    OPTIONS.organicSocial.campaignName,
     (value, priorState) => ({
-      socialOptions: { ...priorState.socialOptions, campaignName: value },
+      organicSocial: {
+        ...priorState.organicSocial,
+        campaignName: value,
+      },
+    }),
+  );
+}
+
+function initPaidMailOptions(
+  form: HTMLFormElement,
+  formState: Observable<FormState>,
+): void {
+  const container = initMediumQuestionsDiv(form, formState, "paid_mail");
+
+  initRadioGroup(
+    container,
+    formState,
+    OPTIONS.paidMail.campaignName,
+    (value, priorState) => ({
+      paidMail: { ...priorState.paidMail, campaignName: value },
+    }),
+  );
+}
+
+function initPaidSearchOptions(
+  form: HTMLFormElement,
+  formState: Observable<FormState>,
+): void {
+  const container = initMediumQuestionsDiv(form, formState, "paid_search");
+
+  initRadioGroup(
+    container,
+    formState,
+    OPTIONS.paidSearch.source,
+    (value, priorState) => ({
+      paidSearch: { ...priorState.paidSearch, source: value },
+    }),
+  );
+
+  initRadioGroup(
+    container,
+    formState,
+    OPTIONS.paidSearch.campaignName,
+    (value, priorState) => ({
+      paidSearch: { ...priorState.paidSearch, campaignName: value },
+    }),
+  );
+}
+
+function initPaidSocialOptions(
+  form: HTMLFormElement,
+  formState: Observable<FormState>,
+): void {
+  const container = initMediumQuestionsDiv(form, formState, "paid_social");
+
+  initRadioGroup(
+    container,
+    formState,
+    OPTIONS.paidSocial.source,
+    (value, priorState) => ({
+      paidSocial: { ...priorState.paidSocial, source: value },
+    }),
+  );
+
+  initRadioGroup(
+    container,
+    formState,
+    OPTIONS.paidSocial.campaignName,
+    (value, priorState) => ({
+      paidSocial: { ...priorState.paidSocial, campaignName: value },
+    }),
+  );
+}
+
+function initPaidSmsOptions(
+  form: HTMLFormElement,
+  formState: Observable<FormState>,
+): void {
+  const container = initMediumQuestionsDiv(form, formState, "paid_sms");
+
+  initRadioGroup(
+    container,
+    formState,
+    OPTIONS.paidSms.source,
+    (value, priorState) => ({
+      paidSms: { ...priorState.paidSms, source: value },
+    }),
+  );
+
+  initRadioGroup(
+    container,
+    formState,
+    OPTIONS.paidSms.campaignName,
+    (value, priorState) => ({
+      paidSms: { ...priorState.paidSms, campaignName: value },
     }),
   );
 }
@@ -227,9 +264,12 @@ function initSocialOptions(
 export function initForm(formState: Observable<FormState>): void {
   const form = document.getElementById("utm-form") as HTMLFormElement;
   initUrl(form, formState);
-  initCommunicationTypeQuestion(form, formState);
-  initAdOptions(form, formState);
+  initMediumQuestion(form, formState);
   initEmailOptions(form, formState);
   initFieldOptions(form, formState);
-  initSocialOptions(form, formState);
+  initOrganicSocialOptions(form, formState);
+  initPaidMailOptions(form, formState);
+  initPaidSearchOptions(form, formState);
+  initPaidSocialOptions(form, formState);
+  initPaidSmsOptions(form, formState);
 }

--- a/src/ts/form/radio.ts
+++ b/src/ts/form/radio.ts
@@ -1,13 +1,12 @@
 export interface RadioOption {
   value: string;
-  label: string;
   description?: string;
 }
 
 export interface RadioGroup {
   id: string;
   label: string;
-  options: Array<RadioOption>;
+  options: readonly RadioOption[];
 }
 
 export function generateRadioGroup(request: RadioGroup): HTMLFieldSetElement {
@@ -36,7 +35,7 @@ export function generateRadioGroup(request: RadioGroup): HTMLFieldSetElement {
     const label = document.createElement("label");
     label.htmlFor = input.id;
     label.classList.add("radio-label");
-    const labelText = document.createTextNode(option.label);
+    const labelText = document.createTextNode(option.value);
     label.appendChild(labelText);
     if (option.description) {
       const description = document.createElement("span");

--- a/src/ts/linkGenerator.ts
+++ b/src/ts/linkGenerator.ts
@@ -44,7 +44,7 @@ export function generateLink(state: FormState): Result {
     errors.push(...urlResult.errors);
   }
 
-  let medium = state.medium;
+  const medium = state.medium;
   let source: string | undefined;
   let campaignName: string | undefined;
   switch (medium) {

--- a/src/ts/linkGenerator.ts
+++ b/src/ts/linkGenerator.ts
@@ -1,5 +1,9 @@
-import { OPTIONS } from "./config/options";
-import { AdOptions, FormState } from "./state/FormState";
+import {
+  CAMPAIGN_NAME_LABEL,
+  MEDIUM_LABEL,
+  SOURCE_LABEL,
+} from "./config/options";
+import { FormState } from "./state/FormState";
 import Observable from "./state/Observable";
 
 function generateUtmString(
@@ -32,27 +36,6 @@ function validateUrl(url: string | undefined): Result {
   return { success: true, url: url };
 }
 
-function determineAdSource(adOptions: AdOptions): string | undefined {
-  switch (adOptions.medium) {
-    case undefined:
-      return undefined;
-    case "paid_mail":
-      return "mailer";
-    case "paid_sms":
-      return "scaletowin";
-    case "paid_tv":
-      return "tv";
-    case "paid_social":
-      return adOptions.source.social;
-    case "paid_search":
-      return adOptions.source.search;
-    case "paid_ooh":
-      return adOptions.source.outOfHome;
-    default:
-      throw new Error(`Unexpected medium "${adOptions.medium}"`);
-  }
-}
-
 export function generateLink(state: FormState): Result {
   const errors: string[] = [];
 
@@ -61,55 +44,53 @@ export function generateLink(state: FormState): Result {
     errors.push(...urlResult.errors);
   }
 
-  let medium: string | undefined;
+  let medium = state.medium;
   let source: string | undefined;
   let campaignName: string | undefined;
-  switch (state.type) {
-    case "ad":
-      medium = state.adOptions.medium;
-      if (!medium) {
-        errors.push(`Missing "${OPTIONS.ad.medium.label}"`);
-      }
-      source = determineAdSource(state.adOptions);
-      if (medium && !source) {
-        errors.push(`Missing "${OPTIONS.ad.source.search.label}"`);
-      }
-      campaignName = state.adOptions.campaignName;
-      if (!campaignName) {
-        errors.push(`Missing "${OPTIONS.ad.campaignName.label}"`);
-      }
+  switch (medium) {
+    case undefined:
+      errors.push(`Missing "${MEDIUM_LABEL}"`);
       break;
     case "email":
-      medium = "email";
-      source = state.emailOptions.source;
-      if (!source) {
-        errors.push(`Missing "${OPTIONS.email.source.label}"`);
-      }
+      source = state.email.source;
+      campaignName = state.email.campaignName;
       break;
     case "field":
-      medium = "field";
-      source = state.fieldOptions.source;
-      if (!source) {
-        errors.push(`Missing "${OPTIONS.field.source.label}"`);
-      }
-      campaignName = state.fieldOptions.campaignName;
-      if (!campaignName) {
-        errors.push(`Missing "${OPTIONS.field.campaignName.label}"`);
-      }
+      source = state.field.source;
+      campaignName = state.field.campaignName;
       break;
-    case "social":
-      medium = "organic_social";
-      source = state.socialOptions.source;
-      if (!source) {
-        errors.push(`Missing "${OPTIONS.social.source.label}"`);
-      }
-      campaignName = state.socialOptions.campaignName;
-      if (!campaignName) {
-        errors.push(`Missing "${OPTIONS.social.campaignName.label}"`);
-      }
+    case "organic_social":
+      source = state.organicSocial.source;
+      campaignName = state.organicSocial.campaignName;
+      break;
+    case "paid_mail":
+      source = state.paidMail.source;
+      campaignName = state.paidMail.campaignName;
+      break;
+    case "paid_search":
+      source = state.paidSearch.source;
+      campaignName = state.paidSearch.campaignName;
+      break;
+    case "paid_social":
+      source = state.paidSocial.source;
+      campaignName = state.paidSocial.campaignName;
+      break;
+    case "paid_sms":
+      source = state.paidSms.source;
+      campaignName = state.paidSms.campaignName;
       break;
     default:
-      errors.push(`Missing "${OPTIONS.communicationType.label}"`);
+      errors.push(
+        `Unrecognized "${MEDIUM_LABEL}", meaning a programming bug: ${medium}`,
+      );
+  }
+
+  // Check for required fields.
+  if (medium) {
+    if (!source && medium !== "paid_mail") {
+      errors.push(`Missing "${SOURCE_LABEL}"`);
+    }
+    if (!campaignName) errors.push(`Missing "${CAMPAIGN_NAME_LABEL}"`);
   }
 
   const queryParam = generateUtmString({

--- a/src/ts/linkGenerator.ts
+++ b/src/ts/linkGenerator.ts
@@ -44,10 +44,9 @@ export function generateLink(state: FormState): Result {
     errors.push(...urlResult.errors);
   }
 
-  const medium = state.medium;
   let source: string | undefined;
   let campaignName: string | undefined;
-  switch (medium) {
+  switch (state.medium) {
     case undefined:
       errors.push(`Missing "${MEDIUM_LABEL}"`);
       break;
@@ -81,20 +80,20 @@ export function generateLink(state: FormState): Result {
       break;
     default:
       errors.push(
-        `Unrecognized "${MEDIUM_LABEL}", meaning a programming bug: ${medium}`,
+        `Unrecognized "${MEDIUM_LABEL}", meaning a programming bug: ${state.medium}`,
       );
   }
 
   // Check for required fields.
-  if (medium) {
-    if (!source && medium !== "paid_mail") {
+  if (state.medium) {
+    if (!source && state.medium !== "paid_mail") {
       errors.push(`Missing "${SOURCE_LABEL}"`);
     }
     if (!campaignName) errors.push(`Missing "${CAMPAIGN_NAME_LABEL}"`);
   }
 
   const queryParam = generateUtmString({
-    medium,
+    medium: state.medium,
     source,
     campaign: campaignName,
   });

--- a/src/ts/state/FormState.ts
+++ b/src/ts/state/FormState.ts
@@ -1,55 +1,44 @@
+import { OPTIONS } from "../config/options";
 import Observable from "./Observable";
 
-export type CommunicationType = "ad" | "email" | "field" | "social";
+export type Medium = (typeof OPTIONS)["medium"]["options"][number]["value"];
 
-export interface AdOptions {
-  medium: string | undefined;
-  source: {
-    social: string | undefined;
-    search: string | undefined;
-    outOfHome: string | undefined;
-  };
-  campaignName: string | undefined;
-}
-
-export interface EmailOptions {
-  source: string | undefined;
-}
-
-export interface FieldOptions {
+interface CommonOptions {
   source: string | undefined;
   campaignName: string | undefined;
 }
 
-export interface SocialOptions {
-  source: string | undefined;
-  campaignName: string | undefined;
-}
+export type EmailOptions = CommonOptions;
+export type FieldOptions = CommonOptions;
+export type OrganicSocialOptions = CommonOptions;
+
+export type PaidMailOptions = CommonOptions;
+export type PaidSearchOptions = CommonOptions;
+export type PaidSocialOptions = CommonOptions;
+export type PaidSmsOptions = CommonOptions;
 
 export interface FormState {
   url: string | undefined;
-  type: CommunicationType | undefined;
-  adOptions: AdOptions;
-  emailOptions: EmailOptions;
-  fieldOptions: FieldOptions;
-  socialOptions: SocialOptions;
+  medium: Medium | undefined;
+  email: EmailOptions;
+  field: FieldOptions;
+  organicSocial: OrganicSocialOptions;
+  paidMail: PaidMailOptions;
+  paidSearch: PaidSearchOptions;
+  paidSocial: PaidSocialOptions;
+  paidSms: PaidSmsOptions;
 }
 
 export function initFormState(): Observable<FormState> {
   return new Observable<FormState>("form state", {
     url: undefined,
-    type: undefined,
-    adOptions: {
-      medium: undefined,
-      source: {
-        social: undefined,
-        search: undefined,
-        outOfHome: undefined,
-      },
-      campaignName: undefined,
-    },
-    emailOptions: { source: undefined },
-    fieldOptions: { source: undefined, campaignName: undefined },
-    socialOptions: { source: undefined, campaignName: undefined },
+    medium: undefined,
+    email: { source: undefined, campaignName: undefined },
+    field: { source: undefined, campaignName: undefined },
+    organicSocial: { source: undefined, campaignName: undefined },
+    paidMail: { source: undefined, campaignName: undefined },
+    paidSearch: { source: undefined, campaignName: undefined },
+    paidSocial: { source: undefined, campaignName: undefined },
+    paidSms: { source: undefined, campaignName: undefined },
   });
 }

--- a/tests/linkGenerator.test.ts
+++ b/tests/linkGenerator.test.ts
@@ -10,26 +10,34 @@ test.describe("generateLink()", () => {
   /// to be `undefined`.
   const DEFAULT: FormState = {
     url: DEFAULT_URL,
-    type: "email",
-    adOptions: {
-      medium: "paid_social",
-      source: {
-        social: "meta",
-        search: undefined,
-        outOfHome: undefined,
-      },
-      campaignName: "lead_gen",
-    },
-    emailOptions: {
+    medium: "email",
+    email: {
       source: "mailchimp",
+      campaignName: "proanimaloregon",
     },
-    fieldOptions: {
+    field: {
       source: "poster",
       campaignName: "lead_gen",
     },
-    socialOptions: {
+    organicSocial: {
       source: "instagram",
       campaignName: "proanimaldc",
+    },
+    paidMail: {
+      source: undefined,
+      campaignName: "lead_gen",
+    },
+    paidSearch: {
+      source: "google",
+      campaignName: "lead_gen",
+    },
+    paidSocial: {
+      source: "meta",
+      campaignName: "lead_gen",
+    },
+    paidSms: {
+      source: "scaletowin",
+      campaignName: "lead_gen",
     },
   };
 
@@ -50,89 +58,33 @@ test.describe("generateLink()", () => {
     });
   });
 
-  test("missing communication type", () => {
-    expect(generateLink({ ...DEFAULT, type: undefined })).toEqual({
+  test("missing medium", () => {
+    expect(generateLink({ ...DEFAULT, medium: undefined })).toEqual({
       success: false,
-      errors: ['Missing "Communication type"'],
-    });
-  });
-
-  test("ad options", () => {
-    const ad: FormState = { ...DEFAULT, type: "ad" };
-    expect(generateLink(ad)).toEqual({
-      success: true,
-      url: `${DEFAULT_URL}?utm_medium=paid_social&utm_source=meta&utm_campaign=lead_gen`,
-    });
-
-    expect(
-      generateLink({
-        ...ad,
-        adOptions: {
-          medium: undefined,
-          source: {
-            search: undefined,
-            social: undefined,
-            outOfHome: undefined,
-          },
-          campaignName: undefined,
-        },
-      }),
-    ).toEqual({
-      success: false,
-      // Note that we don't complain about `source` because it depends on the medium.
-      errors: ['Missing "Medium"', 'Missing "Primary purpose"'],
-    });
-
-    /// Once the `medium` is set, we expect `source` to also be set.
-    expect(
-      generateLink({
-        ...ad,
-        adOptions: {
-          ...ad.adOptions,
-          source: {
-            social: undefined,
-            search: undefined,
-            outOfHome: undefined,
-          },
-        },
-      }),
-    ).toEqual({
-      success: false,
-      errors: ['Missing "Source"'],
-    });
-
-    // Certain mediums imply the `source`.
-    expect(
-      generateLink({
-        ...ad,
-        adOptions: { ...ad.adOptions, medium: "paid_tv" },
-      }),
-    ).toEqual({
-      success: true,
-      url: `${DEFAULT_URL}?utm_medium=paid_tv&utm_source=tv&utm_campaign=lead_gen`,
+      errors: ['Missing "utm_medium"'],
     });
   });
 
   test("email options", () => {
-    const email: FormState = { ...DEFAULT, type: "email" };
+    const email: FormState = { ...DEFAULT, medium: "email" };
     expect(generateLink(email)).toEqual({
       success: true,
-      url: `${DEFAULT_URL}?utm_medium=email&utm_source=mailchimp`,
+      url: `${DEFAULT_URL}?utm_medium=email&utm_source=mailchimp&utm_campaign=proanimaloregon`,
     });
 
     expect(
       generateLink({
         ...email,
-        emailOptions: { source: undefined },
+        email: { source: undefined, campaignName: undefined },
       }),
     ).toEqual({
       success: false,
-      errors: ['Missing "Source"'],
+      errors: ['Missing "utm_source"', 'Missing "utm_campaign"'],
     });
   });
 
   test("field options", () => {
-    const field: FormState = { ...DEFAULT, type: "field" };
+    const field: FormState = { ...DEFAULT, medium: "field" };
     expect(generateLink(field)).toEqual({
       success: true,
       url: `${DEFAULT_URL}?utm_medium=field&utm_source=poster&utm_campaign=lead_gen`,
@@ -141,16 +93,16 @@ test.describe("generateLink()", () => {
     expect(
       generateLink({
         ...field,
-        fieldOptions: { source: undefined, campaignName: undefined },
+        field: { source: undefined, campaignName: undefined },
       }),
     ).toEqual({
       success: false,
-      errors: ['Missing "Source"', 'Missing "Primary purpose"'],
+      errors: ['Missing "utm_source"', 'Missing "utm_campaign"'],
     });
   });
 
-  test("social media options", () => {
-    const social: FormState = { ...DEFAULT, type: "social" };
+  test("organic social media options", () => {
+    const social: FormState = { ...DEFAULT, medium: "organic_social" };
     expect(generateLink(social)).toEqual({
       success: true,
       url: `${DEFAULT_URL}?utm_medium=organic_social&utm_source=instagram&utm_campaign=proanimaldc`,
@@ -159,11 +111,83 @@ test.describe("generateLink()", () => {
     expect(
       generateLink({
         ...social,
-        socialOptions: { source: undefined, campaignName: undefined },
+        organicSocial: { source: undefined, campaignName: undefined },
       }),
     ).toEqual({
       success: false,
-      errors: ['Missing "Source"', 'Missing "Account name"'],
+      errors: ['Missing "utm_source"', 'Missing "utm_campaign"'],
+    });
+  });
+
+  test("paid mail options", () => {
+    const mail: FormState = { ...DEFAULT, medium: "paid_mail" };
+    expect(generateLink(mail)).toEqual({
+      success: true,
+      url: `${DEFAULT_URL}?utm_medium=paid_mail&utm_campaign=lead_gen`,
+    });
+
+    expect(
+      generateLink({
+        ...mail,
+        paidMail: { source: undefined, campaignName: undefined },
+      }),
+    ).toEqual({
+      success: false,
+      errors: ['Missing "utm_campaign"'],
+    });
+  });
+
+  test("paid search options", () => {
+    const search: FormState = { ...DEFAULT, medium: "paid_search" };
+    expect(generateLink(search)).toEqual({
+      success: true,
+      url: `${DEFAULT_URL}?utm_medium=paid_search&utm_source=google&utm_campaign=lead_gen`,
+    });
+
+    expect(
+      generateLink({
+        ...search,
+        paidSearch: { source: undefined, campaignName: undefined },
+      }),
+    ).toEqual({
+      success: false,
+      errors: ['Missing "utm_source"', 'Missing "utm_campaign"'],
+    });
+  });
+
+  test("paid social media options", () => {
+    const social: FormState = { ...DEFAULT, medium: "paid_social" };
+    expect(generateLink(social)).toEqual({
+      success: true,
+      url: `${DEFAULT_URL}?utm_medium=paid_social&utm_source=meta&utm_campaign=lead_gen`,
+    });
+
+    expect(
+      generateLink({
+        ...social,
+        paidSocial: { source: undefined, campaignName: undefined },
+      }),
+    ).toEqual({
+      success: false,
+      errors: ['Missing "utm_source"', 'Missing "utm_campaign"'],
+    });
+  });
+
+  test("paid sms options", () => {
+    const sms: FormState = { ...DEFAULT, medium: "paid_sms" };
+    expect(generateLink(sms)).toEqual({
+      success: true,
+      url: `${DEFAULT_URL}?utm_medium=paid_sms&utm_source=scaletowin&utm_campaign=lead_gen`,
+    });
+
+    expect(
+      generateLink({
+        ...sms,
+        paidSms: { source: undefined, campaignName: undefined },
+      }),
+    ).toEqual({
+      success: false,
+      errors: ['Missing "utm_source"', 'Missing "utm_campaign"'],
     });
   });
 });


### PR DESCRIPTION
Dani doesn't want labels. It's clearer to use the final UTM value. This also helps train the users on the dasbhoard.

A key change in this PR is collapsing `ad` into the distinct `paid_*` mediums.