### PR TITLE
Add support for optional fields

### DIFF
--- a/src/ts/form/initForm.ts
+++ b/src/ts/form/initForm.ts
@@ -4,7 +4,7 @@ import Observable from "../state/Observable";
 import { generateRadioGroup, RadioGroup } from "./radio";
 
 type UpdateFormStateFunction = (
-  value: string,
+  value: string | undefined,
   priorState: FormState,
 ) => Partial<FormState>;
 
@@ -20,12 +20,12 @@ const updateFormState =
     // need to instead always use the text input. For example, if you
     // click a radio button with a text input, we should use
     // the value from its text input rather than from the radio button itself.
-    let value = e.target.value;
+    let value = e.target.value || undefined;
     if (e.target.type === "radio" && e.target.checked) {
       const textInput =
         e.target.parentElement?.querySelector(".radio-text-input");
       if (textInput instanceof HTMLInputElement) {
-        value = textInput.value;
+        value = textInput.value || undefined;
       }
     }
 
@@ -79,7 +79,7 @@ function initUrl(
 
   input.addEventListener(
     "input",
-    updateFormState(formState)((value) => ({ url: value.trim() })),
+    updateFormState(formState)((value) => ({ url: value?.trim() })),
   );
 }
 

--- a/src/ts/form/radio.ts
+++ b/src/ts/form/radio.ts
@@ -8,12 +8,21 @@ export interface RadioGroup {
   id: string;
   label: string;
   options: readonly RadioOption[];
+  optional?: boolean;
 }
 
-function linkRadioTextPair(
-  textInput: HTMLInputElement,
+export const NONE_OPTION: RadioOption = { value: "Do not set this option" };
+
+function generateRadioTextInput(
   radioInput: HTMLInputElement,
-): void {
+): HTMLInputElement {
+  const textInput = document.createElement("input");
+  textInput.type = "text";
+  textInput.classList.add("radio-text-input");
+  textInput.id = `${radioInput.id}-text`;
+  textInput.name = textInput.id;
+  textInput.setAttribute("aria-labelledby", radioInput.id);
+
   textInput.addEventListener("input", () => {
     radioInput.checked = true;
   });
@@ -23,6 +32,8 @@ function linkRadioTextPair(
       textInput.focus();
     }
   });
+
+  return textInput;
 }
 
 function generateRadioOption(
@@ -53,17 +64,10 @@ function generateRadioOption(
   }
   radioDiv.appendChild(label);
 
-  if (!option.textInput) return radioDiv;
-
-  const textInput = document.createElement("input");
-  textInput.type = "text";
-  textInput.classList.add("radio-text-input");
-  textInput.id = `${outerId}-${option.value}-text`;
-  textInput.name = textInput.id;
-  textInput.setAttribute("aria-labelledby", `${outerId}-${option.value}`);
-  radioDiv.appendChild(textInput);
-
-  linkRadioTextPair(textInput, radioInput);
+  if (option.textInput) {
+    const textInput = generateRadioTextInput(radioInput);
+    radioDiv.appendChild(textInput);
+  }
 
   return radioDiv;
 }
@@ -78,7 +82,10 @@ export function generateRadioGroup(request: RadioGroup): HTMLFieldSetElement {
   legend.classList.add("radio-legend");
   fieldSet.appendChild(legend);
 
-  request.options.forEach((option) => {
+  const allOptions = request.optional
+    ? [NONE_OPTION, ...request.options]
+    : request.options;
+  allOptions.forEach((option) => {
     const radioDiv = generateRadioOption(request.id, option);
     fieldSet.appendChild(radioDiv);
   });


### PR DESCRIPTION
You must actively choose the option "Do not set this value". This solves two goals:

1. Reduce the risk of not setting the value when you should. Force the user to make a choice
2. Provide a way to reset the radio group. If you accidentally chose an actual value but wanted to leave it blank, we need some way to reset to "no selection". I could have added a reset button, but it's easier to have an "n/a" radio button.

Note that we don't have to do anything special in `initForm.ts`, like converting the None option to `undefined`. We want to preserve the raw value of the `None` option and pass it to `linkGenerator.ts` because it needs a way to distinguish between a fieldset being completely unanswered versus being marked as none.