### PR TITLE
Refactor result container creation

### DIFF
--- a/src/css/_result.scss
+++ b/src/css/_result.scss
@@ -2,7 +2,8 @@
 @use "theme/colors";
 @use "theme/typography";
 
-.result-container {
+.error-container,
+.success-container {
   font-size: typography.$font-size-md;
 
   max-width: max-content;
@@ -12,18 +13,18 @@
   padding: 10px 15px;
 
   border-radius: borders.$border-radius;
+}
 
-  &:has(ul) {
-    background-color: colors.$red-background;
-    border-left: 3px solid colors.$red-highlight;
-  }
-
-  &:not(:has(ul)) {
-    background-color: colors.$green-background;
-    border-left: 3px solid colors.$green-highlight;
-  }
+.error-container {
+  background-color: colors.$red-background;
+  border-left: 3px solid colors.$red-highlight;
 
   ul {
     opacity: 0.8;
   }
+}
+
+.success-container {
+  background-color: colors.$green-background;
+  border-left: 3px solid colors.$green-highlight;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -31,7 +31,13 @@
         </dd>
       </dl>
       <form id="utm-form"></form>
-      <div class="result-container" id="result-container"></div>
+      <div class="error-container" id="error-container">
+        <p>Cannot generate link:</p>
+        <ul id="error-list"></ul>
+      </div>
+      <div class="success-container" id="success-container" hidden>
+        <p id="generated-link"></p>
+      </div>
     </main>
   </body>
 

--- a/src/ts/linkGenerator.ts
+++ b/src/ts/linkGenerator.ts
@@ -79,35 +79,33 @@ export function generateLink(state: FormState): Result {
     : { success: true, url: `${state.url}${queryParam}` };
 }
 
-function generateSuccess(url: string): HTMLElement[] {
-  const p = document.createElement("p");
-  p.textContent = url;
-  return [p];
-}
-
-function generateErrors(errors: string[]): HTMLElement[] {
-  const p = document.createElement("p");
-  p.textContent = "Cannot generate link:";
-
-  const ul = document.createElement("ul");
-  errors.forEach((err) => {
-    const li = document.createElement("li");
-    li.textContent = err;
-    ul.appendChild(li);
-  });
-  return [p, ul];
+function addErrors(errors: string[]): void {
+  const ul = document.getElementById("error-list") as HTMLUListElement;
+  ul.replaceChildren(
+    ...errors.map((err) => {
+      const li = document.createElement("li");
+      li.textContent = err;
+      return li;
+    }),
+  );
 }
 
 export function subscribeLinkGenerator(formState: Observable<FormState>): void {
-  const container = document.getElementById(
-    "result-container",
+  const errorContainer = document.getElementById(
+    "error-container",
+  ) as HTMLDivElement;
+  const successContainer = document.getElementById(
+    "success-container",
   ) as HTMLDivElement;
   formState.subscribe((state) => {
     const result = generateLink(state);
+    errorContainer.hidden = result.success;
+    successContainer.hidden = !result.success;
     if (result.success) {
-      container.replaceChildren(...generateSuccess(result.url));
+      successContainer.querySelector("#generated-link")!.textContent =
+        result.url;
     } else {
-      container.replaceChildren(...generateErrors(result.errors));
+      addErrors(result.errors);
     }
   });
 }


### PR DESCRIPTION
We now set up the HTML for the containers and overall structure eagerly in `index.html` and only update individual nodes. This will make it easier to set up the copy link button and its event listener so that we only create the node once and don't have to re-create it every time the URL changes.